### PR TITLE
Fix dash blue overlay recoloring other HUD elements

### DIFF
--- a/src/main/java/dev/mayaqq/estrogen/client/Dash.java
+++ b/src/main/java/dev/mayaqq/estrogen/client/Dash.java
@@ -123,6 +123,7 @@ public class Dash {
         RenderSystem.disableBlend();
         RenderSystem.depthMask(true);
         RenderSystem.enableDepthTest();
+        graphics.setShaderColor(1f, 1f, 1f, 1f);
         graphics.getMatrices().pop();
     }
 


### PR DESCRIPTION
This PR aims to fix an issue where the dash's blue color would affect the color of other minor UI elements such as advancement toasts, tutorial toasts, and recipe toasts, FPS counters, etc.