### PR TITLE
Add washing recipe for `create:filter`

### DIFF
--- a/common/src/main/generated/data/estrogen/recipes/splashing/filter.json
+++ b/common/src/main/generated/data/estrogen/recipes/splashing/filter.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:splashing",
+  "ingredients": [
+    {
+      "item": "estrogen:used_filter"
+    }
+  ],
+  "results": [
+    {
+      "item": "create:filter"
+    }
+  ]
+}

--- a/common/src/main/java/dev/mayaqq/estrogen/datagen/EstrogenDatagen.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/datagen/EstrogenDatagen.java
@@ -35,6 +35,7 @@ public class EstrogenDatagen implements DataGeneratorEntrypoint {
         pack.addProvider((Factory<?>) EstrogenMixingRecipes::buildForge);
         pack.addProvider((Factory<?>) EstrogenSequencedAssemblyRecipes::buildFabric);
         pack.addProvider((Factory<?>) EstrogenSequencedAssemblyRecipes::buildForge);
+        pack.addProvider(EstrogenWashingRecipes::new);
         pack.addProvider(EstrogenEntityInteractionRecipe::new);
         pack.addProvider(EstrogenItemApplicationRecipes::new);
 

--- a/common/src/main/java/dev/mayaqq/estrogen/datagen/recipes/create/EstrogenWashingRecipes.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/datagen/recipes/create/EstrogenWashingRecipes.java
@@ -1,0 +1,27 @@
+package dev.mayaqq.estrogen.datagen.recipes.create;
+
+import com.simibubi.create.AllItems;
+import com.simibubi.create.AllRecipeTypes;
+import com.simibubi.create.foundation.data.recipe.ProcessingRecipeGen;
+import com.simibubi.create.foundation.recipe.IRecipeTypeInfo;
+import dev.mayaqq.estrogen.registry.EstrogenItems;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+
+import static dev.mayaqq.estrogen.Estrogen.id;
+
+public class EstrogenWashingRecipes extends ProcessingRecipeGen {
+
+    GeneratedRecipe
+            FILTER = create(id("filter"), recipeBuilder -> recipeBuilder
+                    .require(EstrogenItems.USED_FILTER.get())
+                    .output(AllItems.FILTER.get(), 1));
+
+    public EstrogenWashingRecipes(FabricDataOutput output) {
+        super(output);
+    }
+
+    @Override
+    protected IRecipeTypeInfo getRecipeType() {
+        return AllRecipeTypes.SPLASHING;
+    }
+}


### PR DESCRIPTION
Add splashing/washing recipe for converting `estrogen:used_filter` into `create:filter`.

This seemed like an appropriate way to clean a used filter, so instead of making a feature request, I just wrote it.