### PR TITLE
Fix tick event and improve server dashing

### DIFF
--- a/common/src/main/java/dev/mayaqq/estrogen/client/features/dash/ClientDash.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/client/features/dash/ClientDash.java
@@ -2,12 +2,12 @@ package dev.mayaqq.estrogen.client.features.dash;
 
 import dev.mayaqq.estrogen.client.registry.EstrogenKeybinds;
 import dev.mayaqq.estrogen.config.EstrogenConfig;
+import dev.mayaqq.estrogen.features.dash.CommonDash;
 import dev.mayaqq.estrogen.networking.EstrogenNetworkManager;
 import dev.mayaqq.estrogen.networking.messages.c2s.DashPacket;
 import dev.mayaqq.estrogen.registry.EstrogenAttributes;
 import dev.mayaqq.estrogen.registry.EstrogenEffects;
 import dev.mayaqq.estrogen.registry.blocks.DreamBlock;
-import dev.mayaqq.estrogen.registry.effects.EstrogenEffect;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
@@ -111,7 +111,7 @@ public class ClientDash {
         if (EstrogenKeybinds.DASH_KEY.consumeClick() && !isOnCooldown()) {
             DreamBlock.lookAngle = null;
             EstrogenNetworkManager.CHANNEL.sendToServer(new DashPacket(true));
-            EstrogenEffect.dashing.put(player.getUUID(), 20);
+            CommonDash.setDashing(player.getUUID());
 
             // Set counter to duration of dash
             dashCooldown = 5;

--- a/common/src/main/java/dev/mayaqq/estrogen/features/dash/CommonDash.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/features/dash/CommonDash.java
@@ -1,0 +1,23 @@
+package dev.mayaqq.estrogen.features.dash;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CommonDash {
+
+    private static final long DASH_DURATION = 1000;
+
+    private static final ConcurrentHashMap<UUID, Long> players = new ConcurrentHashMap<>();
+
+    public static void setDashing(UUID player) {
+        players.put(player, System.currentTimeMillis());
+    }
+
+    public static void removeDashing(UUID player) {
+        players.remove(player);
+    }
+
+    public static boolean isPlayerDashing(UUID player) {
+        return players.getOrDefault(player, 0L) + DASH_DURATION > System.currentTimeMillis();
+    }
+}

--- a/common/src/main/java/dev/mayaqq/estrogen/networking/messages/c2s/DashPacket.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/networking/messages/c2s/DashPacket.java
@@ -6,9 +6,9 @@ import com.teamresourceful.resourcefullib.common.network.base.PacketType;
 import com.teamresourceful.resourcefullib.common.network.base.ServerboundPacketType;
 import com.teamresourceful.resourcefullib.common.network.defaults.CodecPacketType;
 import dev.mayaqq.estrogen.Estrogen;
+import dev.mayaqq.estrogen.features.dash.CommonDash;
 import dev.mayaqq.estrogen.registry.EstrogenEffects;
 import dev.mayaqq.estrogen.registry.EstrogenSounds;
-import dev.mayaqq.estrogen.registry.effects.EstrogenEffect;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
@@ -41,7 +41,7 @@ public record DashPacket(boolean sound) implements Packet<DashPacket> {
                 if (player.hasEffect(EstrogenEffects.ESTROGEN_EFFECT.get()) && player.level() instanceof ServerLevel serverLevel) {
                     if (message.sound) serverLevel.playSound(null, player.blockPosition(), EstrogenSounds.DASH.get(), SoundSource.PLAYERS, 1.0F, 1.0F);
                     // dash cooldown
-                    if (message.sound) EstrogenEffect.dashing.put(player.getUUID(), 20);
+                    if (message.sound) CommonDash.setDashing(player.getUUID());
                     // summon particles around player
                     serverLevel.sendParticles(ParticleTypes.CLOUD, player.getX(), player.getY(), player.getZ(), 10, 0.5, 0.5, 0.5, 0.5);
                 }

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/EstrogenEvents.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/EstrogenEvents.java
@@ -88,11 +88,6 @@ public class EstrogenEvents {
     }
 
     public static void playerTickEnd(Player player) {
-        EstrogenEffect.dashing.forEach((uuid, cooldown) -> {
-            if (cooldown > 0) {
-                EstrogenEffect.dashing.put(uuid, cooldown - 1);
-            }
-        });
         if (EstrogenConfig.common().minigameEnabled.get()) {
             if (EstrogenConfig.common().permaDash.get()) {
                 player.addEffect(new MobEffectInstance(ESTROGEN_EFFECT.get(), 20, EstrogenConfig.common().girlPowerLevel.get(), false, false, false));

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/DreamBlock.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/DreamBlock.java
@@ -1,11 +1,11 @@
 package dev.mayaqq.estrogen.registry.blocks;
 
 import dev.mayaqq.estrogen.client.features.dash.ClientDash;
+import dev.mayaqq.estrogen.features.dash.CommonDash;
 import dev.mayaqq.estrogen.registry.blockEntities.DreamBlockEntity;
-import dev.mayaqq.estrogen.registry.effects.EstrogenEffect;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.Mth;
 import net.minecraft.core.Direction;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
@@ -45,10 +45,8 @@ public class DreamBlock extends BaseEntityBlock {
     public @NotNull VoxelShape getCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         if (context instanceof EntityCollisionContext entityCollisionContext) {
             Entity entity = entityCollisionContext.getEntity();
-            if (entity instanceof Player player){
-                if (EstrogenEffect.dashing.getOrDefault(player.getUUID(), 0) > 0 || isInDreamBlock(player)) {
-                    return Shapes.empty();
-                }
+            if (entity instanceof Player player && (CommonDash.isPlayerDashing(player.getUUID()) || isInDreamBlock(player))){
+                return Shapes.empty();
             }
         }
         return Shapes.block();

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/effects/EstrogenEffect.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/effects/EstrogenEffect.java
@@ -2,6 +2,7 @@ package dev.mayaqq.estrogen.registry.effects;
 
 import dev.mayaqq.estrogen.client.features.dash.ClientDash;
 import dev.mayaqq.estrogen.config.EstrogenConfig;
+import dev.mayaqq.estrogen.features.dash.CommonDash;
 import dev.mayaqq.estrogen.registry.EstrogenAttributes;
 import dev.mayaqq.estrogen.utils.PlayerLookup;
 import dev.mayaqq.estrogen.utils.Time;
@@ -23,14 +24,11 @@ import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static dev.mayaqq.estrogen.registry.EstrogenAttributes.*;
 import static dev.mayaqq.estrogen.registry.EstrogenEffects.ESTROGEN_EFFECT;
 
 public class EstrogenEffect extends MobEffect {
-
-    public static ConcurrentHashMap<UUID, Integer> dashing = new ConcurrentHashMap<>();
 
     private static final UUID DASH_MODIFIER_UUID = UUID.fromString("2a2591c5-009f-4b24-97f2-b15f43415e4c");
     private static final UUID FALL_DAMAGE_RESISTANCE_UUID = UUID.fromString("2a2591c5-009f-4b24-97f2-b15f43415e4d");
@@ -54,7 +52,7 @@ public class EstrogenEffect extends MobEffect {
     @Override
     public void removeAttributeModifiers(LivingEntity entity, AttributeMap attributes, int amplifier) {
         super.removeAttributeModifiers(entity, attributes, amplifier);
-        dashing.remove(entity.getUUID());
+        CommonDash.removeDashing(entity.getUUID());
 
         if (entity instanceof ServerPlayer player) {
             sendRemovePlayerStatusEffect(player, ESTROGEN_EFFECT.get(), PlayerLookup.tracking(player).toArray(ServerPlayer[]::new));

--- a/forge/src/main/java/dev/mayaqq/estrogen/forge/EstrogenForgeEvents.java
+++ b/forge/src/main/java/dev/mayaqq/estrogen/forge/EstrogenForgeEvents.java
@@ -19,7 +19,6 @@ import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
@@ -47,9 +46,8 @@ public class EstrogenForgeEvents {
     // Minigame ticking
     @SubscribeEvent
     public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
-        if (event.getPhase() == EventPriority.LOWEST) {
-            EstrogenEvents.playerTickEnd(event.player);
-        }
+        if (event.phase != TickEvent.Phase.END) return;
+        EstrogenEvents.playerTickEnd(event.player);
     }
 
     // Player Tracking


### PR DESCRIPTION
### What this does?

- Creates a new file called CommonDash this is for the logic thats done in common/server.
- Fixes tick event never being called on forge.
- Switched common dash logic from using a tick based system to using a timestamp of dashing start and checking that instead.