### PR TITLE
Fix Mexican Spanish translation syntax errors.

### DIFF
--- a/common/src/main/resources/assets/estrogen/lang/es_mx.json
+++ b/common/src/main/resources/assets/estrogen/lang/es_mx.json
@@ -1,7 +1,7 @@
 {
-  "advancement.estrogen.balls.description": "¿Que ocurre si separas la \”Bola\” del \”Slime\”?",
+  "advancement.estrogen.balls.description": "¿Que ocurre si separas la \"Bola\" del \"Slime\"?",
   "advancement.estrogen.balls.title": "Jijiji",
-  "advancement.estrogen.cookie_jar.description": "Utilizamos \“cookies\” para personalizar y mejorar su experiencia en nuestro sitio, al insertar una \”cookie\” en el Tarro para Galletas aceptas nuestros términos y condiciones.”
+  "advancement.estrogen.cookie_jar.description": "Utilizamos \"cookies\" para personalizar y mejorar su experiencia en nuestro sitio, al insertar una \"cookie\" en el Tarro para Galletas aceptas nuestros términos y condiciones.",
   "advancement.estrogen.cookie_jar.title": "Aceptar cookies",
   "advancement.estrogen.estrogen_dealer.description": "I am the one who knocks",
   "advancement.estrogen.estrogen_dealer.title": "Traficante de Estrógeno",
@@ -38,7 +38,7 @@
   "block.estrogen.estrogen_pill_block": "Caja de Pastillas de Estrógeno ",
   "block.estrogen.filtrated_horse_urine": "Orina de Caballo Filtrada",
   "block.estrogen.horse_urine": "Orina de Caballo",
-  "block.estrogen.liquid_estrogen": "Estrógeno  Líquido”,
+  "block.estrogen.liquid_estrogen": "Estrógeno  Líquido",
   "block.estrogen.molten_amethyst": "Amatista Fundida",
   "block.estrogen.molten_slime": "Slime Derretido",
   "block.estrogen.moth_bed": "Cama Rosada del Arce",


### PR DESCRIPTION
Hello, I found a few JSON syntax errors with the Mexican Spanish localization file that were causing these entries to fail during loading. This PR resolves the issue and will allow them to load.

1. On line 4, the entry was missing the necessary comma.
2. On lines 2, 4, and 41 unicode quotes were used instead of ASCII quotes. While unicode quotes are valid in JSON I believe this was a mistake because they can not be used to start or end a string as seen on line 4, and they can not be escaped using a backslash as seen on line 2 and 41. 