### PR TITLE
Allow float UV values

### DIFF
--- a/common/src/main/java/dev/mayaqq/estrogen/client/entity/player/features/boobs/BoobArmorRenderer.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/client/entity/player/features/boobs/BoobArmorRenderer.java
@@ -29,22 +29,22 @@ public final class BoobArmorRenderer {
     public boolean visible = true;
     public boolean skipDraw;
     private PartPose initalTransform = PartPose.ZERO;
-    private int u;
-    private int v;
-    private int leftU;
-    private int leftV;
-    private int rightU;
-    private int rightV;
+    private float u;
+    private float v;
+    private float leftU;
+    private float leftV;
+    private float rightU;
+    private float rightV;
     private float textureWidth;
     private float textureHeight;
 
     public BoobArmorRenderer() {
-        this.u = 20;
-        this.v = 23;
-        this.leftU = 18;
-        this.leftV = 23;
-        this.rightU = 28;
-        this.rightV = 23;
+        this.u = 20.0F;
+        this.v = 23.0F;
+        this.leftU = 18.0F;
+        this.leftV = 23.0F;
+        this.rightU = 28.0F;
+        this.rightV = 23.0F;
         this.textureWidth = 64.0F;
         this.textureHeight = 32.0F;
         this.createModel();
@@ -109,7 +109,7 @@ public final class BoobArmorRenderer {
         this.models = Collections.singletonList(new BoobArmorRenderer.BoobArmorModel(this.u, this.v, this.leftU, this.leftV, this.rightU, this.rightV, 8, 2, 2, false, this.textureWidth, this.textureHeight));
     }
 
-    public void render(PoseStack stack, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha, int u, int v, int leftU, int leftV, int rightU, int rightV, float textureWidth, float textureHeight) {
+    public void render(PoseStack stack, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha, float u, float v, float leftU, float leftV, float rightU, float rightV, float textureWidth, float textureHeight) {
         if (!this.visible) {
             return;
         }
@@ -187,7 +187,7 @@ public final class BoobArmorRenderer {
     public static class BoobArmorModel {
         private final ModelPart.Polygon[] sides; //private, add to AW/AT or smth, same deal with modelpart.vertex
 
-        public BoobArmorModel(int u, int v, int leftU, int leftV, int rightU, int rightV, float sizeX, float sizeY, float sizeZ, boolean mirror, float squishU, float squishV) {
+        public BoobArmorModel(float u, float v, float leftU, float leftV, float rightU, float rightV, float sizeX, float sizeY, float sizeZ, boolean mirror, float squishU, float squishV) {
             this.sides = new ModelPart.Polygon[4];
 
             ModelPart.Vertex vertex = new ModelPart.Vertex(-4.0F*1.24F, 0.0F, 0.0F, 0.0F, 0.0F);

--- a/common/src/main/java/dev/mayaqq/estrogen/client/entity/player/features/boobs/TextureData.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/client/entity/player/features/boobs/TextureData.java
@@ -2,4 +2,4 @@ package dev.mayaqq.estrogen.client.entity.player.features.boobs;
 
 import net.minecraft.resources.ResourceLocation;
 
-public record TextureData(ResourceLocation location, Integer u, Integer v, Integer leftU, Integer leftV, Integer rightU, Integer rightV, Float textureWidth, Float textureHeight) {}
+public record TextureData(ResourceLocation location, Float u, Float v, Float leftU, Float leftV, Float rightU, Float rightV, Float textureWidth, Float textureHeight) {}

--- a/common/src/main/java/dev/mayaqq/estrogen/mixin/client/PlayerEntityModelMixin.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/mixin/client/PlayerEntityModelMixin.java
@@ -190,7 +190,7 @@ public class PlayerEntityModelMixin<T extends LivingEntity> extends HumanoidMode
             }
             ResourceLocation location;
             return (location = ARMOR_TEXTURE_CACHE.computeIfAbsent(string, ResourceLocation::tryParse)) != null ?
-                    Optional.of(new TextureData(location, 20, 23, 18, 23, 28, 23, 64.0F, 32.0F)) :
+                    Optional.of(new TextureData(location, 20f, 23f, 18f, 23f, 28f, 23f, 64.0F, 32.0F)) :
                     Optional.empty();
         }
     }

--- a/common/src/main/java/dev/mayaqq/estrogen/resources/BreastArmorData.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/resources/BreastArmorData.java
@@ -8,10 +8,10 @@ import net.minecraft.util.GsonHelper;
 
 public class BreastArmorData {
     public ResourceLocation textureLocation;
-    public ResourceLocation overlayLocation = null;
-    public Pair<Integer, Integer> uv;
-    public Pair<Integer, Integer> leftUV;
-    public Pair<Integer, Integer> rightUV;
+    public ResourceLocation overlayLocation;
+    public Pair<Float, Float> uv;
+    public Pair<Float, Float> leftUV;
+    public Pair<Float, Float> rightUV;
     public Pair<Float, Float> textureSize;
 
     public BreastArmorData(JsonElement jsonElement) {
@@ -19,11 +19,11 @@ public class BreastArmorData {
         this.overlayLocation = jsonElement.getAsJsonObject().has("texture_overlay") ?
                 ResourceLocation.tryParse(GsonHelper.getAsString(jsonElement.getAsJsonObject(), "texture_overlay")) : null;
         JsonArray uvArray = GsonHelper.getAsJsonArray(jsonElement.getAsJsonObject(), "uv");
-        this.uv = Pair.of(uvArray.get(0).getAsInt(), uvArray.get(1).getAsInt());
+        this.uv = Pair.of(uvArray.get(0).getAsFloat(), uvArray.get(1).getAsFloat());
         JsonArray leftUVArray = GsonHelper.getAsJsonArray(jsonElement.getAsJsonObject(), "left_uv");
-        this.leftUV = Pair.of(leftUVArray.get(0).getAsInt(), leftUVArray.get(1).getAsInt());
+        this.leftUV = Pair.of(leftUVArray.get(0).getAsFloat(), leftUVArray.get(1).getAsFloat());
         JsonArray rightUVArray = GsonHelper.getAsJsonArray(jsonElement.getAsJsonObject(), "right_uv");
-        this.rightUV = Pair.of(rightUVArray.get(0).getAsInt(), rightUVArray.get(1).getAsInt());
+        this.rightUV = Pair.of(rightUVArray.get(0).getAsFloat(), rightUVArray.get(1).getAsFloat());
         JsonArray textureSizeArray = GsonHelper.getAsJsonArray(jsonElement.getAsJsonObject(), "size");
         this.textureSize = Pair.of(textureSizeArray.get(0).getAsFloat(), textureSizeArray.get(1).getAsFloat());
     }


### PR DESCRIPTION
Allows specifying floats in the various UV fields for custom armor data in case of weird armor models. 
Integers are still supported as normal.

## Example
```json
{
  "texture": "minecraft:textures/models/armor/diamond_layer_1.png",
  "uv": [19.5, 23],
  "left_uv": [18, 23],
  "right_uv": [28, 23],
  "size": [64.0, 32.0]
}
```

<img src="https://github.com/user-attachments/assets/19e61dae-b20e-4a7d-afa3-654f8eeacf9d" width="300">