### PR TITLE
Add best-effort support for a lot of modded chestplates

### DIFF
--- a/common/src/main/resources/assets/ad_astra/estrogen_armor_data/netherite_space_suit.json
+++ b/common/src/main/resources/assets/ad_astra/estrogen_armor_data/netherite_space_suit.json
@@ -1,0 +1,7 @@
+{
+  "texture": "ad_astra:textures/entity/armor/netherite_space_suit.png",
+  "uv": [28, 23],
+  "left_uv": [28, 24],
+  "right_uv": [34, 24],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/ad_astra/estrogen_armor_data/space_suit.json
+++ b/common/src/main/resources/assets/ad_astra/estrogen_armor_data/space_suit.json
@@ -1,0 +1,7 @@
+{
+  "texture": "ad_astra:textures/entity/armor/space_suit.png",
+  "uv": [28, 23],
+  "left_uv": [28, 24],
+  "right_uv": [34, 24],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/aether/estrogen_armor_data/gravitite_chestplate.json
+++ b/common/src/main/resources/assets/aether/estrogen_armor_data/gravitite_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "aether:textures/models/armor/gravitite_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/aether/estrogen_armor_data/neptune_chestplate.json
+++ b/common/src/main/resources/assets/aether/estrogen_armor_data/neptune_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "aether:textures/models/armor/neptune_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/aether/estrogen_armor_data/obsidian_chestplate.json
+++ b/common/src/main/resources/assets/aether/estrogen_armor_data/obsidian_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "aether:textures/models/armor/obsidian_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/aether/estrogen_armor_data/phoenix_chestplate.json
+++ b/common/src/main/resources/assets/aether/estrogen_armor_data/phoenix_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "aether:textures/models/armor/phoenix_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/aether/estrogen_armor_data/valkyrie_chestplate.json
+++ b/common/src/main/resources/assets/aether/estrogen_armor_data/valkyrie_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "aether:textures/models/armor/valkyrie_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/aether/estrogen_armor_data/zanite_chestplate.json
+++ b/common/src/main/resources/assets/aether/estrogen_armor_data/zanite_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "aether:textures/models/armor/zanite_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/alexscaves/estrogen_armor_data/cloak_of_darkness.json
+++ b/common/src/main/resources/assets/alexscaves/estrogen_armor_data/cloak_of_darkness.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexscaves:textures/armor/darkness_armor.png",
+  "uv": [20, 22],
+  "left_uv": [18, 22],
+  "right_uv": [28, 22],
+  "size": [128.0, 128.0]
+}

--- a/common/src/main/resources/assets/alexscaves/estrogen_armor_data/diving_chestplate.json
+++ b/common/src/main/resources/assets/alexscaves/estrogen_armor_data/diving_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexscaves:textures/armor/diving_suit_0.png",
+  "uv": [20, 26],
+  "left_uv": [18, 20],
+  "right_uv": [28, 20],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/alexscaves/estrogen_armor_data/gingerbread_chestplate.json
+++ b/common/src/main/resources/assets/alexscaves/estrogen_armor_data/gingerbread_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexscaves:textures/armor/gingerbread_armor_0.png",
+  "uv": [44, 76],
+  "left_uv": [44, 76],
+  "right_uv": [52, 76],
+  "size": [128.0, 128.0]
+}

--- a/common/src/main/resources/assets/alexscaves/estrogen_armor_data/hazmat_chestplate.json
+++ b/common/src/main/resources/assets/alexscaves/estrogen_armor_data/hazmat_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexscaves:textures/armor/hazmat_suit_0.png",
+  "uv": [20, 38],
+  "left_uv": [18, 38],
+  "right_uv": [28, 38],
+  "size": [128.0, 128.0]
+}

--- a/common/src/main/resources/assets/alexscaves/estrogen_armor_data/primordial_tunic.json
+++ b/common/src/main/resources/assets/alexscaves/estrogen_armor_data/primordial_tunic.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexscaves:textures/armor/primordial_armor_0.png",
+  "uv": [17, 40],
+  "left_uv": [16, 40],
+  "right_uv": [26, 40],
+  "size": [128.0, 128.0]
+}

--- a/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/crocodile_chestplate.json
+++ b/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/crocodile_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexsmobs:textures/armor/crocodile_chestplate.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/rocky_chestplate.json
+++ b/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/rocky_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexsmobs:textures/armor/rocky_chestplate.png",
+  "uv": [10, 12],
+  "left_uv": [11, 12],
+  "right_uv": [11, 12],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/tarantula_hawk_elytra.json
+++ b/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/tarantula_hawk_elytra.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexsmobs:textures/armor/tarantula_hawk_elytra.png",
+  "uv": [24, 10],
+  "left_uv": [24, 10],
+  "right_uv": [30, 10],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/unsettling_kimono.json
+++ b/common/src/main/resources/assets/alexsmobs/estrogen_armor_data/unsettling_kimono.json
@@ -1,0 +1,7 @@
+{
+  "texture": "alexsmobs:textures/armor/unsettling_kimono.png",
+  "uv": [4, 7],
+  "left_uv": [2, 7],
+  "right_uv": [12, 7],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/cataclysm/estrogen_armor_data/bone_reptile_chestplate.json
+++ b/common/src/main/resources/assets/cataclysm/estrogen_armor_data/bone_reptile_chestplate.json
@@ -1,0 +1,7 @@
+{
+    "texture": "cataclysm:textures/armor/bone_reptile_armor.png",
+    "uv": [7, 118],
+    "left_uv": [6, 116],
+    "right_uv": [14, 116],
+    "size": [128.0, 128.0]
+  }

--- a/common/src/main/resources/assets/cataclysm/estrogen_armor_data/cursium_chestplate.json
+++ b/common/src/main/resources/assets/cataclysm/estrogen_armor_data/cursium_chestplate.json
@@ -1,0 +1,7 @@
+{
+    "texture": "cataclysm:textures/armor/cursium_armor.png",
+    "uv": [6, 64],
+    "left_uv": [6, 64],
+    "right_uv": [14, 64],
+    "size": [128.0, 128.0]
+  }

--- a/common/src/main/resources/assets/cataclysm/estrogen_armor_data/ignitium_chestplate.json
+++ b/common/src/main/resources/assets/cataclysm/estrogen_armor_data/ignitium_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "cataclysm:textures/armor/ignitium_armor.png",
+  "uv": [24, 10],
+  "left_uv": [24, 10],
+  "right_uv": [30, 10],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/cataclysm/estrogen_armor_data/ignitium_elytra_chestplate.json
+++ b/common/src/main/resources/assets/cataclysm/estrogen_armor_data/ignitium_elytra_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "cataclysm:textures/armor/ignitium_armor.png",
+  "uv": [24, 10],
+  "left_uv": [24, 10],
+  "right_uv": [30, 10],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_amythest_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_amythest_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_amythest.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_black_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_black_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_black.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_blue_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_blue_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_blue.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_bronze_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_bronze_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_bronze.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_copper_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_copper_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_copper.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_copper_metal_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_copper_metal_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_copper_metal_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_deathworm_red_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_deathworm_red_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_deathworm_red.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_deathworm_white_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_deathworm_white_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_deathworm_white.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_deathworm_yellow_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_deathworm_yellow_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_deathworm_yellow.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_electric_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_electric_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_electric.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_gray_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_gray_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_gray.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_green_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_green_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_green.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_red_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_red_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_red.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_sapphire_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_sapphire_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_sapphire.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_silver_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_silver_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_silver.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_silver_metal_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_silver_metal_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_silver_metal_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_troll_forest_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_troll_forest_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_troll_forest.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_troll_frost_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_troll_frost_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_troll_frost.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_troll_mountain_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_troll_mountain_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_troll_mountain.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_white_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/armor_white_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_white.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/dragonsteel_fire_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/dragonsteel_fire_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_dragonsteel_fire.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/dragonsteel_ice_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/dragonsteel_ice_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_dragonsteel_ice.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/dragonsteel_lightning_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/dragonsteel_lightning_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_dragonsteel_lightning.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/myrmex_desert_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/myrmex_desert_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/myrmex_desert_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/myrmex_jungle_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/myrmex_jungle_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/myrmex_jungle_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/sheep_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/sheep_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/sheep_disguise_layer_1.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 32.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_blue_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_blue_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_blue.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_bronze_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_bronze_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_bronze.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_deepblue_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_deepblue_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_deepblue.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_green_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_green_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_green.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_guardian_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_guardian_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_guardian.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_purple_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_purple_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_purple.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_red_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_red_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_red.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}

--- a/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_teal_chestplate.json
+++ b/common/src/main/resources/assets/iceandfire/estrogen_armor_data/tide_teal_chestplate.json
@@ -1,0 +1,7 @@
+{
+  "texture": "iceandfire:textures/models/armor/armor_tide_teal.png",
+  "uv": [20, 23],
+  "left_uv": [18, 23],
+  "right_uv": [28, 23],
+  "size": [64.0, 64.0]
+}


### PR DESCRIPTION
Adds armor support for the following mods' chestplates:
- L_Ender's Cataclysm
- Ice and Fire: Dragons
- The Aether
- Alex's Caves
- Alex's Mobs
- Ad Astra

Some of the unwraps are not perfect, and I may have missed some things, but some support is better than no support.