### PR TITLE
cookie jar QOL

### DIFF
--- a/common/src/main/java/dev/mayaqq/estrogen/registry/blockEntities/CookieJarBlockEntity.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/blockEntities/CookieJarBlockEntity.java
@@ -52,17 +52,17 @@ public class CookieJarBlockEntity extends SyncedBlockEntity implements Container
         ItemStack itemStackCopy = itemStack.copy();
         int i = 0;
         for (ItemStack jarItemStack : items) {
-            if (!ItemStack.isSameItemSameTags(jarItemStack, itemStackCopy)) continue;
+            if (!jarItemStack.isEmpty() && !ItemStack.isSameItemSameTags(jarItemStack, itemStackCopy)) continue;
 
             ItemStack addToJar = itemStackCopy.split(itemStackCopy.getMaxStackSize() - jarItemStack.getCount());
             addToJar.grow(jarItemStack.getCount());
             items.set(i, addToJar);
-            notifyUpdate();
 
-            if (itemStackCopy.isEmpty()) return ItemStack.EMPTY;
+            if (itemStackCopy.isEmpty()) break;
 
             i++;
         }
+        notifyUpdate();
         return itemStackCopy;
     }
 

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/blockEntities/CookieJarBlockEntity.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/blockEntities/CookieJarBlockEntity.java
@@ -67,6 +67,31 @@ public class CookieJarBlockEntity extends SyncedBlockEntity implements Container
     }
 
     /**
+     * Removes and returns a stack of items from the jar.
+     * @return The stack taken from the jar.
+     */
+    public ItemStack removeItemStack() {
+        ItemStack result = ItemStack.EMPTY;
+        for (int i = items.size() - 1; i >= 0; i--) {
+            ItemStack jarItemStack = items.get(i);
+            if (jarItemStack.isEmpty()) {
+                continue;
+            }
+            if (result.isEmpty()) {
+                result = jarItemStack.split(jarItemStack.getMaxStackSize());
+                continue;
+            }
+
+            if (!ItemStack.isSameItemSameTags(jarItemStack, result)) break;
+            ItemStack fromJarStack = jarItemStack.split(result.getMaxStackSize() - result.getCount());
+            result.grow(fromJarStack.getCount());
+            if (result.getCount() == result.getMaxStackSize()) break;
+        }
+        notifyUpdate();
+        return result;
+    }
+
+    /**
      * Returns number of items.
      */
     public int getCount() {

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/CookieJarBlock.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/CookieJarBlock.java
@@ -75,11 +75,12 @@ public class CookieJarBlock extends BaseEntityBlock implements BEBlock<CookieJar
 
         if (!handItem.isEmpty()) {
             ItemStack remainder = cookieJarBlockEntity.addItemStack(handItem);
-            if (!player.isCreative()) handItem.setCount(remainder.getCount());
             if (ItemStack.matches(handItem, remainder)) {
                 // jar was full, couldn't add item to jar
                 level.playSound(null, pos, EstrogenSounds.JAR_FULL.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
             } else {
+                if (!player.isCreative()) handItem.setCount(remainder.getCount());
+
                 player.awardStat(Stats.ITEM_USED.get(handItem.getItem()));
                 level.playSound(null, pos, EstrogenSounds.JAR_INSERT.get(), SoundSource.BLOCKS, 1.0F, 0.7F + 0.5F * ((float) cookieJarBlockEntity.getCount() / 512));
                 if (level instanceof ServerLevel serverLevel) {
@@ -88,12 +89,14 @@ public class CookieJarBlock extends BaseEntityBlock implements BEBlock<CookieJar
                 }
             }
         } else {
-            ItemStack itemStack = cookieJarBlockEntity.remove1Item();
-            if (!itemStack.isEmpty()) {
+            // take whole stack if crouching
+            ItemStack jarItemStack = player.isShiftKeyDown() ? cookieJarBlockEntity.removeItemStack() : cookieJarBlockEntity.remove1Item();
+
+            if (!jarItemStack.isEmpty()) {
                 // removing item from jar
                 level.playSound(null, pos, EstrogenSounds.JAR_INSERT.get(), SoundSource.BLOCKS, 1.0F, 0.7F + 0.5F * ((float) cookieJarBlockEntity.getCount() / 512));
                 if (level instanceof ServerLevel) {
-                    player.getInventory().placeItemBackInInventory(itemStack);
+                    player.getInventory().placeItemBackInInventory(jarItemStack);
                 }
             } else {
                 // jar was empty, couldn't remove item from jar

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/CookieJarBlock.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/CookieJarBlock.java
@@ -74,21 +74,18 @@ public class CookieJarBlock extends BaseEntityBlock implements BEBlock<CookieJar
         ItemStack handItem = player.getItemInHand(hand);
 
         if (!handItem.isEmpty()) {
-            // if crouching add entire stack, else add only 1
-            ItemStack itemToBeAdded = player.isShiftKeyDown() ? handItem : handItem.copyWithCount(1);
-
-            ItemStack remainder = cookieJarBlockEntity.addItemStack(itemToBeAdded);
+            ItemStack remainder = cookieJarBlockEntity.addItemStack(handItem);
             if (!player.isCreative()) handItem.setCount(remainder.getCount());
             if (ItemStack.matches(handItem, remainder)) {
                 // jar was full, couldn't add item to jar
                 level.playSound(null, pos, EstrogenSounds.JAR_FULL.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
-            }
-
-            player.awardStat(Stats.ITEM_USED.get(handItem.getItem()));
-            level.playSound(null, pos, EstrogenSounds.JAR_INSERT.get(), SoundSource.BLOCKS, 1.0F, 0.7F + 0.5F * ((float) cookieJarBlockEntity.getCount() / 512));
-            if (level instanceof ServerLevel serverLevel) {
-                EstrogenAdvancementCriteria.INSERT_JAR.trigger((ServerPlayer) player);
-                serverLevel.sendParticles(ParticleTypes.CRIT, (double)pos.getX() + 0.5, (double)pos.getY() + 1.2, (double)pos.getZ() + 0.5, 7, 0.0, 0.0, 0.0, 0.0);
+            } else {
+                player.awardStat(Stats.ITEM_USED.get(handItem.getItem()));
+                level.playSound(null, pos, EstrogenSounds.JAR_INSERT.get(), SoundSource.BLOCKS, 1.0F, 0.7F + 0.5F * ((float) cookieJarBlockEntity.getCount() / 512));
+                if (level instanceof ServerLevel serverLevel) {
+                    EstrogenAdvancementCriteria.INSERT_JAR.trigger((ServerPlayer) player);
+                    serverLevel.sendParticles(ParticleTypes.CRIT, (double) pos.getX() + 0.5, (double) pos.getY() + 1.2, (double) pos.getZ() + 0.5, 7, 0.0, 0.0, 0.0, 0.0);
+                }
             }
         } else {
             ItemStack itemStack = cookieJarBlockEntity.remove1Item();

--- a/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/CookieJarBlock.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/blocks/CookieJarBlock.java
@@ -74,20 +74,21 @@ public class CookieJarBlock extends BaseEntityBlock implements BEBlock<CookieJar
         ItemStack handItem = player.getItemInHand(hand);
 
         if (!handItem.isEmpty()) {
-            if (cookieJarBlockEntity.canAddItem(handItem)) {
-                // adding item to jar
-                cookieJarBlockEntity.add1Item(handItem);
-                if (!player.isCreative()) handItem.shrink(1);
+            // if crouching add entire stack, else add only 1
+            ItemStack itemToBeAdded = player.isShiftKeyDown() ? handItem : handItem.copyWithCount(1);
 
-                player.awardStat(Stats.ITEM_USED.get(handItem.getItem()));
-                level.playSound(null, pos, EstrogenSounds.JAR_INSERT.get(), SoundSource.BLOCKS, 1.0F, 0.7F + 0.5F * ((float) cookieJarBlockEntity.getCount() / 512));
-                if (level instanceof ServerLevel serverLevel) {
-                    EstrogenAdvancementCriteria.INSERT_JAR.trigger((ServerPlayer) player);
-                    serverLevel.sendParticles(ParticleTypes.CRIT, (double)pos.getX() + 0.5, (double)pos.getY() + 1.2, (double)pos.getZ() + 0.5, 7, 0.0, 0.0, 0.0, 0.0);
-                }
-            } else {
+            ItemStack remainder = cookieJarBlockEntity.addItemStack(itemToBeAdded);
+            if (!player.isCreative()) handItem.setCount(remainder.getCount());
+            if (ItemStack.matches(handItem, remainder)) {
                 // jar was full, couldn't add item to jar
                 level.playSound(null, pos, EstrogenSounds.JAR_FULL.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
+            }
+
+            player.awardStat(Stats.ITEM_USED.get(handItem.getItem()));
+            level.playSound(null, pos, EstrogenSounds.JAR_INSERT.get(), SoundSource.BLOCKS, 1.0F, 0.7F + 0.5F * ((float) cookieJarBlockEntity.getCount() / 512));
+            if (level instanceof ServerLevel serverLevel) {
+                EstrogenAdvancementCriteria.INSERT_JAR.trigger((ServerPlayer) player);
+                serverLevel.sendParticles(ParticleTypes.CRIT, (double)pos.getX() + 0.5, (double)pos.getY() + 1.2, (double)pos.getZ() + 0.5, 7, 0.0, 0.0, 0.0, 0.0);
             }
         } else {
             ItemStack itemStack = cookieJarBlockEntity.remove1Item();


### PR DESCRIPTION
changes to cookie jar interactions:
- right click with a cookie will now try to add the entire stack
- right click with an empty hand will still try to take one cookie
- shift + right click with an empty hand will now try to take a stack of cookies