### PR TITLE
Handle null or empty styles in streamStyleItems()

### DIFF
--- a/common/src/main/java/dev/mayaqq/estrogen/registry/items/ThighHighsItem.java
+++ b/common/src/main/java/dev/mayaqq/estrogen/registry/items/ThighHighsItem.java
@@ -109,6 +109,9 @@ public class ThighHighsItem extends Item implements Bauble {
     }
 
     public Stream<ItemStack> streamStyleItems() {
+        if (styles == null || styles.isEmpty()) {
+            return Stream.empty();
+        }
         return styles.stream().map(s -> {
             ItemStack stack = getDefaultInstance();
             setStyle(stack, s);


### PR DESCRIPTION
Playing with my modpack, I was getting this error:
```
[Render thread/ERROR]: Exception thrown while invoking ClientPlayConnectionEvents.JOIN
    java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "this.styles" is null
```
Full report: https://mclo.gs/IB0dmyt


This issue was preventing Simple Voice Chat from connecting to the server.

To fix it, I added a simple check to ensure the function properly handles null values.

I'm not a Java expert, so I’m not sure if this is the best approach, but based on my tests, the fix works.