### PR TITLE
Fixed End City Spawn for thigh highs

### DIFF
--- a/forge/src/main/resources/data/estrogen/loot_modifiers/thigh_highs_loot.json
+++ b/forge/src/main/resources/data/estrogen/loot_modifiers/thigh_highs_loot.json
@@ -22,7 +22,7 @@
         },
         {
           "condition": "forge:loot_table_id",
-          "loot_table_id": "minecraft:chests/end_city"
+          "loot_table_id": "minecraft:chests/end_city_treasure"
         },
         {
           "condition": "forge:loot_table_id",


### PR DESCRIPTION
End city's loot table is called end_city_treasure, so I fixed it real quick. Should fix #258 