### PR TITLE
more dream block changes

### DIFF
--- a/src/main/kotlin/dev/mayaqq/estrogen/client/content/EstrogenRenderer.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/content/EstrogenRenderer.kt
@@ -51,7 +51,7 @@ object EstrogenRenderer {
     @Subscription
     fun onLoadShaders(event: CoreShaderRegistrationEvent) {
         event.register(id("rendertype_estrogen_dream"), DefaultVertexFormat.BLOCK, ::dreamBlockShader)
-        event.register(id("dreamblock_overlay"), DefaultVertexFormat.POSITION, ::dreamBlockOverlayShader)
+        event.register(id("dreamblock_overlay"), DefaultVertexFormat.POSITION_COLOR, ::dreamBlockOverlayShader)
         event.register(id("blit_with_depth"), DefaultVertexFormat.BLIT_SCREEN, ::blitWithDepthShader)
         //event.register(recipeId("particle_cutout_color"), DefaultVertexFormat.PARTICLE, ::cutoutColorShader)
     }

--- a/src/main/kotlin/dev/mayaqq/estrogen/client/content/blockRenderers/dreamBlock/DreamBlockRenderer.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/content/blockRenderers/dreamBlock/DreamBlockRenderer.kt
@@ -120,7 +120,7 @@ class DreamBlockRenderer(val ctx: BlockEntityRendererProvider.Context) : BlockEn
         uv: Pair<Int, Int> = 0 to 0
     ) {
         val borderChannel = if (isBorder) 255 else 0
-        val seeThroughChannel = if (DreamBlockEffect.isInDreamBlock) 255 else 0
+        val seeThroughChannel = if (DreamBlockEffect.isEyeInDream) 255 else 0
         consumer.vertex(pose, position.x, position.y, position.z)
             .color(borderChannel, seeThroughChannel, 0, 0)
             .uv(uv.first.toFloat(), uv.second.toFloat())

--- a/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DashOverlay.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DashOverlay.kt
@@ -14,6 +14,7 @@ import dev.mayaqq.cynosure.utils.colors.Color
 import dev.mayaqq.cynosure.utils.colors.floatBlue
 import dev.mayaqq.cynosure.utils.colors.floatGreen
 import dev.mayaqq.cynosure.utils.colors.floatRed
+import dev.mayaqq.cynosure.utils.toBlockPos
 import dev.mayaqq.estrogen.client.content.EstrogenRenderTypes
 import dev.mayaqq.estrogen.client.content.EstrogenRenderer
 import dev.mayaqq.estrogen.client.content.blockRenderers.dreamBlock.texture.DynamicDreamTexture
@@ -22,14 +23,18 @@ import dev.mayaqq.estrogen.client.features.dash.ClientDash.getDashLevel
 import dev.mayaqq.estrogen.client.features.dash.ClientDash.isOnCooldown
 import dev.mayaqq.estrogen.config.EstrogenClientConfig
 import dev.mayaqq.estrogen.content.EstrogenEffects
+import dev.mayaqq.estrogen.content.blockEntities.DreamBlockEntity
 import dev.mayaqq.estrogen.utils.EstrogenColors
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.renderer.LightTexture
 import net.minecraft.client.renderer.ShaderInstance
+import net.minecraft.core.BlockPos
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.phys.Vec3
 import org.joml.Matrix4f
+import kotlin.math.floor
 
 object DashOverlay : HudOverlay {
     private val DASH_OVERLAY = ResourceLocation("textures/misc/nausea.png")
@@ -41,8 +46,11 @@ object DashOverlay : HudOverlay {
             renderOverlay(graphics, dc.floatRed, dc.floatGreen, dc.floatBlue)
         }
         if (DreamBlockEffect.isInDreamBlock) {
-            //renderOverlay(graphics, 0.2f, 0.0f, 0.2f)
-            renderDream(graphics)
+            if (DreamBlockEffect.isEyeInDream) {
+                renderDream(graphics)
+            } else {
+                renderOverlay(graphics, 0.2f, 0.0f, 0.2f)
+            }
         }
         if (TextRendererFeatures.obfuscate) {
             renderOverlay(graphics, 0.1f, 0.3f, 0.3f, 0.1f)

--- a/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DashOverlay.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DashOverlay.kt
@@ -14,8 +14,6 @@ import dev.mayaqq.cynosure.utils.colors.Color
 import dev.mayaqq.cynosure.utils.colors.floatBlue
 import dev.mayaqq.cynosure.utils.colors.floatGreen
 import dev.mayaqq.cynosure.utils.colors.floatRed
-import dev.mayaqq.cynosure.utils.toBlockPos
-import dev.mayaqq.estrogen.client.content.EstrogenRenderTypes
 import dev.mayaqq.estrogen.client.content.EstrogenRenderer
 import dev.mayaqq.estrogen.client.content.blockRenderers.dreamBlock.texture.DynamicDreamTexture
 import dev.mayaqq.estrogen.client.features.TextRendererFeatures
@@ -23,18 +21,12 @@ import dev.mayaqq.estrogen.client.features.dash.ClientDash.getDashLevel
 import dev.mayaqq.estrogen.client.features.dash.ClientDash.isOnCooldown
 import dev.mayaqq.estrogen.config.EstrogenClientConfig
 import dev.mayaqq.estrogen.content.EstrogenEffects
-import dev.mayaqq.estrogen.content.blockEntities.DreamBlockEntity
 import dev.mayaqq.estrogen.utils.EstrogenColors
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.gui.GuiGraphics
-import net.minecraft.client.renderer.LightTexture
-import net.minecraft.client.renderer.ShaderInstance
-import net.minecraft.core.BlockPos
 import net.minecraft.resources.ResourceLocation
-import net.minecraft.world.phys.Vec3
 import org.joml.Matrix4f
-import kotlin.math.floor
 
 object DashOverlay : HudOverlay {
     private val DASH_OVERLAY = ResourceLocation("textures/misc/nausea.png")
@@ -47,7 +39,7 @@ object DashOverlay : HudOverlay {
         }
         if (DreamBlockEffect.isInDreamBlock) {
             if (DreamBlockEffect.isEyeInDream) {
-                renderDream(graphics)
+                renderDream(graphics, partialTick)
             } else {
                 renderOverlay(graphics, 0.2f, 0.0f, 0.2f)
             }
@@ -94,7 +86,7 @@ object DashOverlay : HudOverlay {
         }
     }
 
-    private fun renderDream(graphics: GuiGraphics) {
+    private fun renderDream(graphics: GuiGraphics, partialTick: Float) {
         graphics.pushPop {
             translate(graphics.guiWidth().toFloat() / 2.0f, graphics.guiHeight().toFloat() / 2.0f, 0.0f)
             scale(1.5f, 1.5f, 1.5f)
@@ -103,18 +95,22 @@ object DashOverlay : HudOverlay {
             RenderSystem.setShaderTexture(0, DynamicDreamTexture.ID)
             RenderSystem.setShader { EstrogenRenderer.dreamBlockOverlayShader }
             val bufferBuilder = Tesselator.getInstance().builder
-            bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION)
+            bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR)
             val width = graphics.guiWidth()
             val height = graphics.guiHeight()
-            vertex(bufferBuilder, lastPose, 0, 0)
-            vertex(bufferBuilder, lastPose, 0, height)
-            vertex(bufferBuilder, lastPose, width, height)
-            vertex(bufferBuilder, lastPose, width, 0)
+            vertex(bufferBuilder, lastPose, 0, 0, partialTick)
+            vertex(bufferBuilder, lastPose, 0, height, partialTick)
+            vertex(bufferBuilder, lastPose, width, height, partialTick)
+            vertex(bufferBuilder, lastPose, width, 0, partialTick)
             BufferUploader.drawWithShader(bufferBuilder.end())
         }
     }
 }
 
-private fun vertex(bufferBuilder: BufferBuilder, pose: Matrix4f, x: Int, y: Int) {
-    bufferBuilder.vertex(pose, x.toFloat(), y.toFloat(), -90f).endVertex()
+private fun vertex(bufferBuilder: BufferBuilder, pose: Matrix4f, x: Int, y: Int, partialTick: Float) {
+    val eyeTime = (DreamBlockEffect.eyeDreamTick.toFloat() + partialTick - 5f).coerceIn(0f, 5f) / 5f
+    bufferBuilder
+        .vertex(pose, x.toFloat(), y.toFloat(), -90f)
+        .color(eyeTime, 0f, 0f, 0f)
+        .endVertex()
 }

--- a/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DreamBlockEffect.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DreamBlockEffect.kt
@@ -23,7 +23,8 @@ object DreamBlockEffect {
         private set
     var isEyeInDream = false
         private set
-    var dreamBlockTick = 0
+    private var dreamBlockTick = 0
+    var eyeDreamTick = 0
         private set
 
     @Subscription
@@ -42,6 +43,9 @@ object DreamBlockEffect {
             }
             isInDreamBlock = true
             isEyeInDream = player.clientLevel.getBlockEntity(player.eyePosition.toBlockPos()) is DreamBlockEntity
+            if (isEyeInDream) {
+                eyeDreamTick++
+            } else eyeDreamTick = 0
         } else {
             if (isInDreamBlock) {
                 player.playSound(EstrogenSounds.DREAM_BLOCK_EXIT, 1.0f, 1.0f)
@@ -51,6 +55,7 @@ object DreamBlockEffect {
                 sound = null
             }
             dreamBlockTick = 0
+            eyeDreamTick = 0
             isInDreamBlock = false
             isEyeInDream = false
         }

--- a/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DreamBlockEffect.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/DreamBlockEffect.kt
@@ -6,17 +6,25 @@ import dev.mayaqq.cynosure.client.events.ClientTickEvent
 import dev.mayaqq.cynosure.core.Environment
 import dev.mayaqq.cynosure.events.api.EventSubscriber
 import dev.mayaqq.cynosure.events.api.Subscription
+import dev.mayaqq.cynosure.utils.toBlockPos
 import dev.mayaqq.estrogen.client.content.sounds.DreamBlockSoundInstance
 import dev.mayaqq.estrogen.content.EstrogenSounds
+import dev.mayaqq.estrogen.content.blockEntities.DreamBlockEntity
 import dev.mayaqq.estrogen.content.blocks.DreamBlock
 import net.minecraft.client.Minecraft
+import net.minecraft.core.BlockPos
+import net.minecraft.world.phys.Vec3
+import kotlin.math.floor
 
 @EventSubscriber(env = [Environment.CLIENT])
 object DreamBlockEffect {
     private var sound: DreamBlockSoundInstance? = null
     var isInDreamBlock = false
         private set
-    private var dreamBlockTick = 0
+    var isEyeInDream = false
+        private set
+    var dreamBlockTick = 0
+        private set
 
     @Subscription
     fun tick(event: ClientTickEvent.End) {
@@ -33,6 +41,7 @@ object DreamBlockEffect {
                 }
             }
             isInDreamBlock = true
+            isEyeInDream = player.clientLevel.getBlockEntity(player.eyePosition.toBlockPos()) is DreamBlockEntity
         } else {
             if (isInDreamBlock) {
                 player.playSound(EstrogenSounds.DREAM_BLOCK_EXIT, 1.0f, 1.0f)
@@ -43,6 +52,12 @@ object DreamBlockEffect {
             }
             dreamBlockTick = 0
             isInDreamBlock = false
+            isEyeInDream = false
         }
+    }
+
+    // Remove this when cynosure pr is approved...!
+    private fun Vec3.toBlockPos(): BlockPos {
+        return BlockPos(floor(this.x).toInt(), floor(this.y).toInt(), floor(this.z).toInt())
     }
 }

--- a/src/main/kotlin/dev/mayaqq/estrogen/content/items/DreamBottleItem.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/content/items/DreamBottleItem.kt
@@ -1,7 +1,9 @@
 package dev.mayaqq.estrogen.content.items
 
+import dev.mayaqq.cynosure.utils.toVector3d
 import dev.mayaqq.estrogen.content.EstrogenBlocks
 import dev.mayaqq.estrogen.content.EstrogenSounds
+import dev.mayaqq.estrogen.content.blockEntities.DreamBlockEntity
 import dev.mayaqq.estrogen.content.blocks.DreamBlock
 import net.minecraft.sounds.SoundEvent
 import net.minecraft.world.InteractionResult
@@ -11,6 +13,8 @@ import net.minecraft.world.item.context.BlockPlaceContext
 import net.minecraft.world.item.context.UseOnContext
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.phys.shapes.BooleanOp
+import net.minecraft.world.phys.shapes.Shapes
 
 class DreamBottleItem(p0: Block, p1: Properties) : ItemNameBlockItem(p0, p1) {
 
@@ -20,6 +24,14 @@ class DreamBottleItem(p0: Block, p1: Properties) : ItemNameBlockItem(p0, p1) {
         .setValue(DreamBlock.PERSISTENT, true)
 
     override fun place(context: BlockPlaceContext): InteractionResult {
+        val player = context.player ?: return InteractionResult.FAIL
+        val pos = context.clickedPos
+        if (Shapes.joinIsNotEmpty(
+                Shapes.block().move(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble()),
+                Shapes.create(player.boundingBox),
+                BooleanOp.AND
+        )) return InteractionResult.FAIL
+
         val result = super.place(context)
         if (result == InteractionResult.SUCCESS && context.player != null && !context.player!!
                 .isCreative

--- a/src/main/kotlin/dev/mayaqq/estrogen/content/items/DreamBottleItem.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/content/items/DreamBottleItem.kt
@@ -7,6 +7,7 @@ import dev.mayaqq.estrogen.content.blockEntities.DreamBlockEntity
 import dev.mayaqq.estrogen.content.blocks.DreamBlock
 import net.minecraft.sounds.SoundEvent
 import net.minecraft.world.InteractionResult
+import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.ItemNameBlockItem
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.context.BlockPlaceContext
@@ -21,24 +22,8 @@ class DreamBottleItem(p0: Block, p1: Properties) : ItemNameBlockItem(p0, p1) {
 
     public override fun getPlaceSound(state: BlockState): SoundEvent = EstrogenSounds.DREAM_BLOCK_PLACE
 
-    override fun getPlacementState(p0: BlockPlaceContext): BlockState = EstrogenBlocks.DreamBlock.defaultBlockState()
-        .setValue(DreamBlock.PERSISTENT, true)
-
-    override fun place(context: BlockPlaceContext): InteractionResult {
-        val pos = context.clickedPos
-        val blockAABB = AABB(pos)
-        val entitiesInside = context.level.getEntities(null, blockAABB) {
-            it.isAlive && !it.isSpectator
-        }
-        if (entitiesInside.isNotEmpty()) return InteractionResult.FAIL
-
-        val result = super.place(context)
-        if (result == InteractionResult.SUCCESS && context.player != null && !context.player!!
-                .isCreative
-        ) {
-            context.player!!.inventory.placeItemBackInInventory(Items.GLASS_BOTTLE.defaultInstance)
-        }
-        return result
+    override fun getPlacementState(context: BlockPlaceContext): BlockState? {
+        return super.getPlacementState(context)?.setValue(DreamBlock.PERSISTENT, true)
     }
 
     override fun useOn(context: UseOnContext): InteractionResult {

--- a/src/main/kotlin/dev/mayaqq/estrogen/content/items/DreamBottleItem.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/content/items/DreamBottleItem.kt
@@ -13,6 +13,7 @@ import net.minecraft.world.item.context.BlockPlaceContext
 import net.minecraft.world.item.context.UseOnContext
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.shapes.BooleanOp
 import net.minecraft.world.phys.shapes.Shapes
 
@@ -24,13 +25,12 @@ class DreamBottleItem(p0: Block, p1: Properties) : ItemNameBlockItem(p0, p1) {
         .setValue(DreamBlock.PERSISTENT, true)
 
     override fun place(context: BlockPlaceContext): InteractionResult {
-        val player = context.player ?: return InteractionResult.FAIL
         val pos = context.clickedPos
-        if (Shapes.joinIsNotEmpty(
-                Shapes.block().move(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble()),
-                Shapes.create(player.boundingBox),
-                BooleanOp.AND
-        )) return InteractionResult.FAIL
+        val blockAABB = AABB(pos)
+        val entitiesInside = context.level.getEntities(null, blockAABB) {
+            it.isAlive && !it.isSpectator
+        }
+        if (entitiesInside.isNotEmpty()) return InteractionResult.FAIL
 
         val result = super.place(context)
         if (result == InteractionResult.SUCCESS && context.player != null && !context.player!!

--- a/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.fsh
+++ b/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.fsh
@@ -6,6 +6,7 @@ uniform sampler2D Sampler0;
 uniform float GameTime;
 
 in vec2 texProj0;
+in vec4 vertexColor;
 
 out vec4 fragColor;
 
@@ -14,10 +15,11 @@ out vec4 fragColor;
 void main() {
     float f = 0.2;
     float angle = atan(texProj0.y, texProj0.x);
+    float A = pow(vertexColor.x, 3) * (4.0 - 3.0 * vertexColor.x);
     float see_through_dist = 0.02 * (sin(7 * angle + 15708 * GameTime) + sin(9 * angle - 14137 * GameTime));
-    if (length(texProj0) < 0.3 + see_through_dist) discard;
+    if (length(texProj0) < A * (0.3 + see_through_dist)) discard;
     vec3 color;
-    if (length(texProj0) < 0.32 + see_through_dist) {
+    if (length(texProj0) < A * (0.32 + see_through_dist)) {
         color = vec3(1.0);
     } else {
         color = vec3(0.0);

--- a/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.fsh
+++ b/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.fsh
@@ -15,7 +15,7 @@ out vec4 fragColor;
 void main() {
     float f = 0.2;
     float angle = atan(texProj0.y, texProj0.x);
-    float A = pow(vertexColor.x, 3) * (4.0 - 3.0 * vertexColor.x);
+    float A = vertexColor.x / (2.0 * vertexColor.x * (vertexColor.x - 1.0) + 1.0);
     float see_through_dist = 0.02 * (sin(7 * angle + 15708 * GameTime) + sin(9 * angle - 14137 * GameTime));
     if (length(texProj0) < A * (0.3 + see_through_dist)) discard;
     vec3 color;

--- a/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.json
+++ b/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.json
@@ -7,7 +7,8 @@
   "vertex": "estrogen:dreamblock_overlay",
   "fragment": "estrogen:dreamblock_overlay",
   "attributes": [
-    "Position"
+    "Position",
+    "Color"
   ],
   "samplers": [
     { "name": "Sampler0" }

--- a/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.vsh
+++ b/src/main/resources/assets/estrogen/shaders/core/dreamblock_overlay.vsh
@@ -3,14 +3,17 @@
 #moj_import <projection.glsl>
 
 in vec3 Position;
+in vec4 Color;
 
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 uniform vec2 ScreenSize;
 
 out vec2 texProj0;
+out vec4 vertexColor;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
     texProj0 = (projection_from_position(gl_Position).xy - vec2(0.5, 0.5)) * ScreenSize / ScreenSize.y;
+    vertexColor = Color;
 }


### PR DESCRIPTION
- only play overlay when player head is inside dream block
- add see through window opening animation
- prevent player from placing dream blocks within themself