### PR TITLE
Partial Fix For Chest Rendering Disappearing

### DIFF
--- a/src/main/java/dev/mayaqq/estrogen/mixin/client/ReceivingLevelScreenMixin.java
+++ b/src/main/java/dev/mayaqq/estrogen/mixin/client/ReceivingLevelScreenMixin.java
@@ -1,6 +1,6 @@
 package dev.mayaqq.estrogen.mixin.client;
 
-import dev.mayaqq.estrogen.config.types.ChestConfig;
+import dev.mayaqq.estrogen.client.EstrogenClientKt;
 import net.minecraft.client.gui.screens.ReceivingLevelScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,6 +11,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ReceivingLevelScreenMixin {
     @Inject(method = "onClose()V", at = @At("TAIL"))
     private void estrogen$onClose(CallbackInfo ci) {
-        ChestConfig.sync();
+        EstrogenClientKt.setChestConfigSet(false);
     }
 }

--- a/src/main/kotlin/dev/mayaqq/estrogen/client/EstrogenClient.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/EstrogenClient.kt
@@ -44,7 +44,7 @@ const val THIGH_HIGH_MODELS_DIRECTORY = "models/thigh_highs"
 
 const val THIGH_HIGH_ITEM_TEXTURES = "textures/item/thigh_highs"
 
-internal var chestConfigSet = false
+var chestConfigSet = false
 
 fun estrogenClient() {
     loadConfig(EstrogenClientConfig)


### PR DESCRIPTION
Fix for chest rendering disabling when player switches dimension or gets kicked (chestConfig in BoobFeatureRenderer becomes null). Doesn't account for when player respawns because ReceivingLevelScreen mixin doesn't fire when that happens.