### PR TITLE
fix dash getting recharged when dashing upwards

### DIFF
--- a/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/ClientDash.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/client/features/dash/ClientDash.kt
@@ -242,7 +242,7 @@ object ClientDash {
     }
 
     private fun canRefresh(player: Player): Boolean {
-        return player.onGround() || player.level().getBlockState(player.blockPosition()).block is LiquidBlock || player.onClimbable()
+        return (player.onGround() || player.level().getBlockState(player.blockPosition()).block is LiquidBlock || player.onClimbable()) && dashCooldown < 5
     }
 
     fun isOnCooldown(): Boolean {


### PR DESCRIPTION
player.onGround stays true for the first tick of the dash, so needed to ignore that tick