### PR TITLE
fix: don't inject estrogen into veins

### DIFF
--- a/src/main/kotlin/dev/mayaqq/estrogen/Estrogen.kt
+++ b/src/main/kotlin/dev/mayaqq/estrogen/Estrogen.kt
@@ -82,7 +82,7 @@ object Estrogen : Logger by LoggerFactory.getLogger(MOD_NAME), RegistryManager b
             ResourceKey.create(Registries.PLACED_FEATURE, id("memorial"))
         )
 
-        info("Injecting Estrogen into your veins!")
+        info("Injecting Estrogen into your body!")
     }
 
     private inline val isFabric get() = currentLoader == Loader.FABRIC


### PR DESCRIPTION
Injecting estrogen into your veins is considered an antipattern in modern Kotlin and has been superseded by more stable APIs. This PR generalizes the log message away from the deprecated practice.